### PR TITLE
Adding spans forseti fixes 2

### DIFF
--- a/google/cloud/forseti/common/opencensus/tracing.py
+++ b/google/cloud/forseti/common/opencensus/tracing.py
@@ -287,7 +287,7 @@ def trace(attr=None):
                 to a function
             """
             if OPENCENSUS_ENABLED:
-                tracer = get_tracer(self)
+                tracer = get_tracer(self, attr)
                 module_str = func.__module__.split('.')[-1]
                 start_span(tracer, module_str, func.__name__)
             result = func(self, *args, **kwargs)

--- a/google/cloud/forseti/common/opencensus/tracing.py
+++ b/google/cloud/forseti/common/opencensus/tracing.py
@@ -169,7 +169,10 @@ def set_attributes(tracer, **kwargs):
         kwargs (dict): A set of attributes to set to the current span.
     """
     for key, value in kwargs.items():
-        tracer.add_attribute_to_current_span(key, value)
+        try:
+            tracer.add_attribute_to_current_span(key, value)
+        except Exception as e:
+            LOGGER.warning("Couldn't set attribute %s=%s to current span", key, value)
 
 def traced(cls):
     """Class decorator

--- a/google/cloud/forseti/common/opencensus/tracing.py
+++ b/google/cloud/forseti/common/opencensus/tracing.py
@@ -163,7 +163,7 @@ def end_span(tracer, **kwargs):
     tracer.end_span()
 
 def set_attributes(tracer, **kwargs):
-    """Sets attributes
+    """Set current span attributes.
 
     Args:
         tracer (opencensus.trace.tracer.Tracer): OpenCensus tracer object.
@@ -184,7 +184,7 @@ def get_tracer(inst, attr=None):
     Otherwise, it will look for a tracer in the DEFAULT_ATTRIBUTES before
     falling back on the OpenCensus execution context tracer.
 
-    Arguments:
+    Args:
         inst: An instance of a class.
         attr (str, optional): The attribute to get / set the tracer from / to.
 
@@ -215,35 +215,37 @@ def get_tracer(inst, attr=None):
     return tracer
 
 def traced(cls):
-    """Class decorator
+    """Class decorator.
 
     Args:
-        cls (object): Class to decorate
+        cls (object): Class to decorate.
+
     Returns:
-        object: Decorated class
+        object: Decorated class.
     """
     for name, func in inspect.getmembers(cls, inspect.ismethod):
         setattr(cls, name, trace_decorator(func))
     return cls
 
 def trace_decorator(func):
-    """ Method decorator to trace a method
+    """Method decorator to trace a class method.
 
     Args:
-        func (func): Class method to be traced
+        func (func): Class method to be traced.
+
     Returns:
-        wrapper: Decorated class method
+        wrapper: Decorated class method.
     """
 
     def wrapper(self, *args, **kwargs):
-        """ Wrapper method
+        """Wrapper method.
 
         Args:
-            *args: Argument list passed to a function
-            **kwargs: Variable number of arguments dictionary passed
-                to a function
+            *args: Argument list passed to the method.
+            **kwargs: Argument dict passed to the method.
+
         Returns:
-            func: Function
+            func: Function.
         """
         tracer = execution_context.get_opencensus_tracer()
         LOGGER.debug('%s.%s: %s', func.__module__, func.__name__,
@@ -258,12 +260,6 @@ def trace_decorator(func):
 def trace(attr=None):
     """Decorator to trace class methods.
 
-    This decorator expect the tracer is set in the class via an instance
-    attribute, or is fetchable using a lambda function.
-
-    If nothing is passed to the decorator, it will use the execution context to
-    get the tracer.
-
     Args:
         attr (str): The attribute to fetch from the instance.
 
@@ -271,12 +267,13 @@ def trace(attr=None):
         func: The decorated class method.
     """
     def decorator(func):
-        """Method decorator
+        """Method decorator.
 
         Args:
-            func (func): Function to be decorated
+            func (func): Function to be decorated.
+
         Returns:
-            func: Decorated function
+            func: Decorated function.
         """
         def wrapper(self, *args, **kwargs):
             """Wrapper class

--- a/google/cloud/forseti/common/opencensus/tracing.py
+++ b/google/cloud/forseti/common/opencensus/tracing.py
@@ -247,13 +247,14 @@ def trace_decorator(func):
         Returns:
             func: Function.
         """
-        tracer = execution_context.get_opencensus_tracer()
-        LOGGER.debug('%s.%s: %s', func.__module__, func.__name__,
-                     tracer.span_context)
-        if hasattr(self, 'config'):
-            self.config.tracer = tracer
-        else:
-            self.tracer = tracer
+        if OPENCENSUS_ENABLED:
+            tracer = execution_context.get_opencensus_tracer()
+            LOGGER.debug('%s.%s: %s', func.__module__, func.__name__,
+                         tracer.span_context)
+            if hasattr(self, 'config'):
+                self.config.tracer = tracer
+            else:
+                self.tracer = tracer
         return func(self, *args, **kwargs)
     return wrapper
 

--- a/google/cloud/forseti/common/opencensus/tracing.py
+++ b/google/cloud/forseti/common/opencensus/tracing.py
@@ -137,9 +137,6 @@ def start_span(tracer, module, function, kind=None):
         module (str): The module name.
         function (str): The function name.
         kind (opencensus.trace.span.SpanKind): The span kind.
-
-    Returns:
-        span: (opencensus.trace.span): The span object.
     """
     if tracer is not None:
         LOGGER.info('%s.%s: %s', module, function, tracer.span_context)
@@ -150,7 +147,6 @@ def start_span(tracer, module, function, kind=None):
         span.span_kind = kind
         tracer.add_attribute_to_current_span('module', module)
         tracer.add_attribute_to_current_span('function', function)
-    return span
 
 def end_span(tracer, **kwargs):
     """End a span.

--- a/google/cloud/forseti/common/opencensus/tracing.py
+++ b/google/cloud/forseti/common/opencensus/tracing.py
@@ -210,7 +210,7 @@ def get_tracer(inst, attr=None):
             rsetattr(inst, attr, tracer)
 
         # Log span context
-        LOGGER.info("%s: %s", inst.__name__, tracer.span_context)
+        LOGGER.info("%s: %s", inst, tracer.span_context)
 
     return tracer
 

--- a/google/cloud/forseti/common/opencensus/tracing.py
+++ b/google/cloud/forseti/common/opencensus/tracing.py
@@ -139,7 +139,7 @@ def start_span(tracer, module, function, kind=None):
         kind (opencensus.trace.span.SpanKind): The span kind.
 
     Returns:
-        span: (opencensus.trace.span): The span object
+        span: (opencensus.trace.span): The span object.
     """
     LOGGER.info('%s.%s: %s', module, function, tracer.span_context)
     if kind is None:

--- a/google/cloud/forseti/common/opencensus/tracing.py
+++ b/google/cloud/forseti/common/opencensus/tracing.py
@@ -141,14 +141,15 @@ def start_span(tracer, module, function, kind=None):
     Returns:
         span: (opencensus.trace.span): The span object.
     """
-    LOGGER.info('%s.%s: %s', module, function, tracer.span_context)
-    if kind is None:
-        kind = SpanKind.SERVER
-    span = tracer.start_span()
-    span.name = '[{}] {}'.format(module, function)
-    span.span_kind = kind
-    tracer.add_attribute_to_current_span('module', module)
-    tracer.add_attribute_to_current_span('function', function)
+    if tracer is not None:
+        LOGGER.info('%s.%s: %s', module, function, tracer.span_context)
+        if kind is None:
+            kind = SpanKind.SERVER
+        span = tracer.start_span()
+        span.name = '[{}] {}'.format(module, function)
+        span.span_kind = kind
+        tracer.add_attribute_to_current_span('module', module)
+        tracer.add_attribute_to_current_span('function', function)
     return span
 
 def end_span(tracer, **kwargs):
@@ -158,9 +159,10 @@ def end_span(tracer, **kwargs):
         tracer (opencensus.trace.tracer.Tracer): OpenCensus tracer object.
         kwargs (dict): A set of attributes to set to the current span.
     """
-    LOGGER.info(tracer.span_context)
-    set_attributes(tracer, **kwargs)
-    tracer.end_span()
+    if tracer is not None:
+        LOGGER.info(tracer.span_context)
+        set_attributes(tracer, **kwargs)
+        tracer.end_span()
 
 def set_attributes(tracer, **kwargs):
     """Set current span attributes.

--- a/google/cloud/forseti/services/inventory/crawler.py
+++ b/google/cloud/forseti/services/inventory/crawler.py
@@ -313,7 +313,6 @@ def run_crawler(storage,
         QueueProgresser: The progresser implemented in inventory
     """
     tracer = config.service_config.tracer
-    LOGGER.info(tracer.span_context)
     tracing.start_span(tracer, 'inventory', 'run_crawler')
     client_config = config.get_api_quota_configs()
     client_config['domain_super_admin_email'] = config.get_gsuite_admin_email()

--- a/google/cloud/forseti/services/inventory/crawler.py
+++ b/google/cloud/forseti/services/inventory/crawler.py
@@ -100,7 +100,7 @@ class Crawler(crawler.Crawler):
         resource.accept(self)
         return self.config.progresser
 
-    @tracing.trace(lambda x: x.config.tracer)
+    @tracing.trace()
     def visit(self, resource):
         """Handle a newly found resource.
 
@@ -176,7 +176,7 @@ class Crawler(crawler.Crawler):
         self.config.storage.warning(warning_message)
         self.config.progresser.on_warning(error)
 
-    @tracing.trace(lambda x: x.config.tracer)
+    @tracing.trace()
     def update(self, resource):
         """Update the row of an existing resource
 

--- a/google/cloud/forseti/services/inventory/crawler.py
+++ b/google/cloud/forseti/services/inventory/crawler.py
@@ -135,8 +135,8 @@ class Crawler(crawler.Crawler):
             raise
         else:
             progresser.on_new_object(resource)
-        #finally:
-            #tracing.end_span(self.config.tracer, **attrs)
+        finally:
+            tracing.end_span(self.config.tracer, **attrs)
 
     def dispatch(self, callback):
         """Dispatch crawling of a subtree.

--- a/google/cloud/forseti/services/inventory/inventory.py
+++ b/google/cloud/forseti/services/inventory/inventory.py
@@ -166,7 +166,6 @@ def run_inventory(service_config,
         Exception: Reraises any exception.
     """
     tracer = service_config.tracer
-    LOGGER.info(tracer.span_context)
     tracing.start_span(tracer, 'inventory', 'run_inventory')
     storage_cls = service_config.get_storage_class()
     with storage_cls(session) as storage:

--- a/google/cloud/forseti/services/inventory/service.py
+++ b/google/cloud/forseti/services/inventory/service.py
@@ -157,7 +157,7 @@ class GrpcInventory(inventory_pb2_grpc.InventoryServicer):
         return inventory_pb2.DeleteReply(
             inventory=inventory_pb_from_object(inventory_index))
 
-    @tracing.trace(lambda x: x.config.tracer)
+    @tracing.trace()
     def Purge(self, request, _):
         """Purge desired inventory data.
 

--- a/google/cloud/forseti/services/inventory/service.py
+++ b/google/cloud/forseti/services/inventory/service.py
@@ -59,7 +59,7 @@ def inventory_pb_from_object(inventory_index):
 class GrpcInventory(inventory_pb2_grpc.InventoryServicer):
     """Inventory gRPC handler."""
 
-    def __init__(self, inventory_api, config):
+    def __init__(self, inventory_api):
         """Initialize
 
         Args:
@@ -67,7 +67,6 @@ class GrpcInventory(inventory_pb2_grpc.InventoryServicer):
         """
         super(GrpcInventory, self).__init__()
         self.inventory = inventory_api
-        self.config = config
 
     def Ping(self, request, _):
         """Ping implemented to check service availability.


### PR DESCRIPTION
- [x] Cleanup @tracing.trace() decorator syntax (no need for lambda function anymore)
- [x] Decorator can now gather tracer from default attributes, custom attribute, or OpenCensus context
- [x] Tracing code now doesn't throw exception if tracing libraries are uninstalled (or tracing disabled)
- [x] Implement `get_tracer` function which gives a cleaner way to get tracers.
- [x] Nested attributes (such as 'config.something.hello') are now working fine with the decorators.
- [x] Catch exceptions when `set_attributes` fail
- [x] Fixed a bug where we were passing an unneeded argument to a gRPC service